### PR TITLE
fix: 엘라스틱서치 비활성화 조건부 설정 추가

### DIFF
--- a/src/main/java/com/beauty4u/backend/elasticsearch/ElasticsearchIndexInitializer.java
+++ b/src/main/java/com/beauty4u/backend/elasticsearch/ElasticsearchIndexInitializer.java
@@ -3,7 +3,9 @@ package com.beauty4u.backend.elasticsearch;
 import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
 import co.elastic.clients.elasticsearch.indices.IndexSettings;
 import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.document.Document;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
@@ -13,6 +15,8 @@ import java.io.IOException;
 
 // 엘라스틱서치의 인덱스를 자동 생성하고 관리하는 클래스
 @Component
+@Slf4j
+@ConditionalOnProperty(name = "elasticsearch.enabled", havingValue = "true", matchIfMissing = false)
 public class ElasticsearchIndexInitializer {
 
     // 엘라스틱서치 작업 위한 핵심 클래스
@@ -27,23 +31,27 @@ public class ElasticsearchIndexInitializer {
 
     @PostConstruct
     public void createIndex() throws IOException {
-        // 해당 인덱스 존재하지 않을 때마나 생성
-        if (!elasticsearchOperations.indexOps(IndexCoordinates.of(indexName)).exists()) {
-            IndexSettings.Builder settingsBuilder = new IndexSettings.Builder()
-                    .numberOfShards("1")
-                    .numberOfReplicas("0");
+        try {
+            // 해당 인덱스 존재하지 않을 때마나 생성
+            if (!elasticsearchOperations.indexOps(IndexCoordinates.of(indexName)).exists()) {
+                IndexSettings.Builder settingsBuilder = new IndexSettings.Builder()
+                        .numberOfShards("1")
+                        .numberOfReplicas("0");
 
-            TypeMapping.Builder mappingBuilder = new TypeMapping.Builder()
-                    .properties("goodsName",p -> p.text(t->t.analyzer("standard")));
+                TypeMapping.Builder mappingBuilder = new TypeMapping.Builder()
+                        .properties("goodsName", p -> p.text(t -> t.analyzer("standard")));
 
 
-            // 인덱스 생성
-            elasticsearchOperations.indexOps(IndexCoordinates.of(indexName))
-                    .create();
+                // 인덱스 생성
+                elasticsearchOperations.indexOps(IndexCoordinates.of(indexName))
+                        .create();
 
-            // 인덱스 매핑
-            elasticsearchOperations.indexOps(IndexCoordinates.of(indexName))
-                    .putMapping(Document.parse(mappingBuilder.build().toString()));
+                // 인덱스 매핑
+                elasticsearchOperations.indexOps(IndexCoordinates.of(indexName))
+                        .putMapping(Document.parse(mappingBuilder.build().toString()));
+            }
+        } catch (Exception e) {
+            log.error("Elasticsearch initialization failed, but application will continue to run", e);
         }
     }
 }

--- a/src/main/java/com/beauty4u/backend/goods/query/controller/GoodsQueryController.java
+++ b/src/main/java/com/beauty4u/backend/goods/query/controller/GoodsQueryController.java
@@ -9,6 +9,7 @@ import com.beauty4u.backend.goods.query.service.GoodsQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,6 +19,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/goods")
 @Tag(name = "Goods", description = "상품 조회 API")
+@ConditionalOnProperty(name = "elasticsearch.enabled", havingValue = "true", matchIfMissing = false)
 public class GoodsQueryController {
 
     private final GoodsQueryService goodsQueryService;

--- a/src/main/java/com/beauty4u/backend/goods/query/elasticsearch/repository/GoodsSearchRepository.java
+++ b/src/main/java/com/beauty4u/backend/goods/query/elasticsearch/repository/GoodsSearchRepository.java
@@ -1,6 +1,7 @@
 package com.beauty4u.backend.goods.query.elasticsearch.repository;
 
 import com.beauty4u.backend.goods.query.elasticsearch.document.GoodsDocument;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.elasticsearch.annotations.Query;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 import org.springframework.stereotype.Repository;
@@ -8,6 +9,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
+@ConditionalOnProperty(name = "elasticsearch.enabled", havingValue = "true", matchIfMissing = false)
 public interface GoodsSearchRepository extends ElasticsearchRepository<GoodsDocument, String> {
     @Query("{\"wildcard\": {\"goods_name\": \"*?0*\"}}")
 // 검색 단어가 포함된 상품 전체 검색

--- a/src/main/java/com/beauty4u/backend/goods/query/service/GoodsQueryService.java
+++ b/src/main/java/com/beauty4u/backend/goods/query/service/GoodsQueryService.java
@@ -8,8 +8,8 @@ import com.beauty4u.backend.goods.query.elasticsearch.document.GoodsDocument;
 import com.beauty4u.backend.goods.query.elasticsearch.repository.GoodsSearchRepository;
 import com.beauty4u.backend.goods.query.mapper.GoodsQueryMapper;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.ibatis.session.SqlSession;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Service
 @Transactional(readOnly = true)
+@ConditionalOnProperty(name = "elasticsearch.enabled", havingValue = "true", matchIfMissing = false)
 public class GoodsQueryService {
     private final SqlSession sqlSession;
     private final GoodsSearchRepository goodsSearchRepository;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,9 @@ spring:
   data:
     mongodb:
       uri: mongodb+srv://${MONGODB_USER}:${MONGODB_PASSWORD}@cluster0.avtro.mongodb.net/${MONGODB_DATABASE}?retryWrites=true&w=majority
+    elasticsearch:
+      repositories:
+        enabled: false
 
 
 
@@ -32,6 +35,7 @@ spring:
     password: ${ELASTIC_PASSWORD}
     index:
       name: goods
+
 
 mybatis:
   configuration:


### PR DESCRIPTION
🌟개요
---

- 엘라스틱서치 비활성화 조건부 설정 추가

🌐연결된 Issues
---
Closes #{이슈넘버}

📋작업사항
---

- 엘라스틱서치 비활성화 조건부 설정을 추가하여
엘라스틱 서치 서버가 실행되어 있지 않아도 해당 기능을 제외한 채 서버가 돌아갑니다. 

✏️작성한 이슈 외 작업사항
---

✅체크리스트
---
- [ ] PR 규칙을 준수하였는가?
- [ ] 이슈번호를 작성하였는가?
- [ ] 추가/수정 사항을 설명하였는가?
