### PR TITLE
feat: 제품의 해당 연도 모든 매출액 조회 백 기능 구현

### DIFF
--- a/src/main/java/com/beauty4u/backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/beauty4u/backend/common/exception/ErrorCode.java
@@ -88,6 +88,7 @@ public enum ErrorCode {
 
     // 특정 상품의 매출액
     GOODS_SALES_COMPARE_FIND_FAIL(HttpStatus.BAD_REQUEST, "제품의 전년 대비 같은 월 비교 실패"),
+    GOODS_SALES_MONTHLY_LIST_FIND_FAIL(HttpStatus.BAD_REQUEST, "제품의 해당 연도 모든 매출액 조회 실패"),
 
     // 팀 게시판 (teamspace)
     NOT_SAVED_TEAMBOARD(HttpStatus.CONFLICT, "팀 게시판 글 등록 실패"),

--- a/src/main/java/com/beauty4u/backend/common/success/SuccessCode.java
+++ b/src/main/java/com/beauty4u/backend/common/success/SuccessCode.java
@@ -137,6 +137,7 @@ public enum SuccessCode {
 
     // 제품에 대한 매출
     GOODS_SALES_FIND_SUCCESS(HttpStatus.OK, "제품의 전년 대비 같은 월 비교 성공"),
+    GOODS_SALES_MONTHLY_LIST_FIND_SUCCESS(HttpStatus.OK, "제품의 해당 연도 모든 매출액 조회 성공"),
 
     // 폴더 (folder)
     FOLDER_SAVE_SUCCESS(HttpStatus.OK, "폴더 생성 성공"),
@@ -151,7 +152,6 @@ public enum SuccessCode {
     TEAMBOARD_REPLY_SAVE_SUCCESS(HttpStatus.CREATED, "팀 게시판 댓글 등록 성공"),
     TEAMBOARD_REPLY_UPDATE_SUCCESS(HttpStatus.OK, "팀 게시판 댓글 수정 성공"),
     TEAMBOARD_REPLY_DELETE_SUCCESS(HttpStatus.OK, "팀 게시판 댓글 삭제 성공"),
-
     TEAMBOARD_FIND_LIST_SUCCESS(HttpStatus.OK, "팀 게시판 글 목록 조회 성공"),
     TEAMBOARD_FIND_DETAIL_SUCCESS(HttpStatus.OK, "팀 게시판 글 상세 조회 성공");
 

--- a/src/main/java/com/beauty4u/backend/goods/query/controller/GoodsSalesQueryController.java
+++ b/src/main/java/com/beauty4u/backend/goods/query/controller/GoodsSalesQueryController.java
@@ -4,6 +4,8 @@ import com.beauty4u.backend.common.response.ApiResponse;
 import com.beauty4u.backend.common.response.ResponseUtil;
 import com.beauty4u.backend.common.success.SuccessCode;
 import com.beauty4u.backend.goods.query.dto.GoodsSalesFilterDTO;
+import com.beauty4u.backend.goods.query.dto.GoodsSalesMonthlyListFilterDTO;
+import com.beauty4u.backend.goods.query.dto.GoodsSalesMonthlyListResDTO;
 import com.beauty4u.backend.goods.query.dto.GoodsSalesResDTO;
 import com.beauty4u.backend.goods.query.service.GoodsSalesQueryService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,6 +16,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -27,7 +31,7 @@ public class GoodsSalesQueryController {
     @Operation(summary = "제품의 전년 대비 같은 월 비교", description = "제품의 전년 대비 같은 월 매출액 비교")
     @GetMapping("/sales/{goodsCode}")
     public ResponseEntity<ApiResponse<GoodsSalesResDTO>> findSalesGoods(
-            @PathVariable String goodsCode,
+            @PathVariable("goodsCode") String goodsCode,
             GoodsSalesFilterDTO goodsSalesFilterDTO
     ) {
 
@@ -35,5 +39,18 @@ public class GoodsSalesQueryController {
                 = goodsSalesQueryService.findSalesGoods(goodsCode, goodsSalesFilterDTO);
 
         return ResponseUtil.successResponse(SuccessCode.GOODS_SALES_FIND_SUCCESS, goodsSalesResDTO);
+    }
+
+    @Operation(summary = "제품의 해당 연도 모든 매출액 조회", description = "제품의 해당 연도의 모든 매출액 목록을 조회한다.")
+    @GetMapping("/sales/list/{goodsCode}")
+    public ResponseEntity<ApiResponse<List<GoodsSalesMonthlyListResDTO>>> findSalesGoodsMonthlyList(
+            @PathVariable("goodsCode") String goodsCode,
+            GoodsSalesMonthlyListFilterDTO goodsSalesMonthlyListFilterDTO
+    ) {
+
+        List<GoodsSalesMonthlyListResDTO> goodsSalesMonthlyListResDTO
+                = goodsSalesQueryService.findSalesGoodsMonthlyList(goodsCode, goodsSalesMonthlyListFilterDTO);
+
+        return ResponseUtil.successResponse(SuccessCode.GOODS_SALES_MONTHLY_LIST_FIND_SUCCESS);
     }
 }

--- a/src/main/java/com/beauty4u/backend/goods/query/dto/GoodsSalesMonthlyListFilterDTO.java
+++ b/src/main/java/com/beauty4u/backend/goods/query/dto/GoodsSalesMonthlyListFilterDTO.java
@@ -1,0 +1,15 @@
+package com.beauty4u.backend.goods.query.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GoodsSalesMonthlyListFilterDTO {
+
+    private Integer year;
+}

--- a/src/main/java/com/beauty4u/backend/goods/query/dto/GoodsSalesMonthlyListResDTO.java
+++ b/src/main/java/com/beauty4u/backend/goods/query/dto/GoodsSalesMonthlyListResDTO.java
@@ -1,0 +1,16 @@
+package com.beauty4u.backend.goods.query.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GoodsSalesMonthlyListResDTO {
+
+    private Integer month;
+    private Long sales;
+}

--- a/src/main/java/com/beauty4u/backend/goods/query/service/GoodsSalesQueryService.java
+++ b/src/main/java/com/beauty4u/backend/goods/query/service/GoodsSalesQueryService.java
@@ -3,10 +3,15 @@ package com.beauty4u.backend.goods.query.service;
 import com.beauty4u.backend.common.exception.CustomException;
 import com.beauty4u.backend.common.exception.ErrorCode;
 import com.beauty4u.backend.goods.query.dto.GoodsSalesFilterDTO;
+import com.beauty4u.backend.goods.query.dto.GoodsSalesMonthlyListFilterDTO;
+import com.beauty4u.backend.goods.query.dto.GoodsSalesMonthlyListResDTO;
 import com.beauty4u.backend.goods.query.dto.GoodsSalesResDTO;
 import com.beauty4u.backend.goods.query.mapper.GoodsSalesQueryMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -61,5 +66,32 @@ public class GoodsSalesQueryService {
 
         double increaseRate = (double) (currentSales - lastSales) / lastSales * 100;
         return Math.round(increaseRate * 10) / 10.0; // 소수점 첫째 자리까지 반올림
+    }
+
+    public List<GoodsSalesMonthlyListResDTO> findSalesGoodsMonthlyList(String goodsCode, GoodsSalesMonthlyListFilterDTO goodsSalesMonthlyListFilterDTO) {
+
+        List<GoodsSalesMonthlyListResDTO> goodsSalesMonthlyListResDTOS = new ArrayList<>();
+
+        try {
+            // 각 월에 대한 매출액 조회
+            for (int month = 1; month <= 12; month++) {
+                Long goodsMonthlySales = goodsSalesQueryMapper.findGoodsMonthlySales(
+                        goodsCode,
+                        month,
+                        goodsSalesMonthlyListFilterDTO.getYear()
+                );
+
+                // 각 월에 대한 dto 생성
+                GoodsSalesMonthlyListResDTO goodsSalesMonthlyListResDTO
+                        = new GoodsSalesMonthlyListResDTO(month, goodsMonthlySales);
+
+                // 만들어진 dto 추가
+                goodsSalesMonthlyListResDTOS.add(goodsSalesMonthlyListResDTO);
+            }
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.GOODS_SALES_MONTHLY_LIST_FIND_FAIL);
+        }
+
+        return goodsSalesMonthlyListResDTOS;
     }
 }

--- a/src/main/resources/mapper/goods/GoodsSalesMapper.xml
+++ b/src/main/resources/mapper/goods/GoodsSalesMapper.xml
@@ -10,6 +10,7 @@
         WHERE goods_code = #{goodsCode}
         AND YEAR(created_date) = #{year}
         AND MONTH(created_date) = #{month}
+        AND order_status = 'PURCHASED'
     </select>
 
 </mapper>


### PR DESCRIPTION
🌟개요
---
제품의 해당 연도 모든 매출액 조회 기능 구현

🌐연결된 Issues
---
Closes #215 

📋작업사항
---
- 제품의 해당 연도 모든 매출액 조회
- 월에 대한 매출액을 조회하는 메서드 이용
- 필터링에 연도 추가
- 해당 연도에 각 월에 대한 매출액 목록 조회

✏️작성한 이슈 외 작업사항
---

✅체크리스트
---
- [ ] PR 규칙을 준수하였는가?
- [ ] 이슈번호를 작성하였는가?
- [ ] 추가/수정 사항을 설명하였는가?
