### PR TITLE
feat: 날짜별 상품 매출 증가, 하락률 구현

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,6 @@ services:
       - xpack.security.enabled=false
     ports:
       - "${ELASTIC_PORT}:9200"
-      - 9300:9300
     volumes:
       - ./elasticsearch:/usr/share/elasticsearch/data
     networks:
@@ -67,7 +66,6 @@ services:
     image: docker.elastic.co/logstash/logstash:7.14.1
     ports:
       - 5000:5000
-      - 9600:9600
     volumes:
       - ./logstash/pipeline:/usr/share/logstash/pipeline
     depends_on:

--- a/src/main/java/com/beauty4u/backend/common/aggregate/PeriodType.java
+++ b/src/main/java/com/beauty4u/backend/common/aggregate/PeriodType.java
@@ -1,0 +1,10 @@
+package com.beauty4u.backend.common.aggregate;
+
+public enum PeriodType {
+    DAILY,
+    WEEKLY,
+    MONTHLY,
+    QUARTER,
+    HALF,
+    YEARLY
+}

--- a/src/main/java/com/beauty4u/backend/common/success/SuccessCode.java
+++ b/src/main/java/com/beauty4u/backend/common/success/SuccessCode.java
@@ -38,8 +38,9 @@ public enum SuccessCode {
     GOODS_FIND_LIST_SUBCATEGORYLIST_SUCCESS(HttpStatus.OK, "상위 카테고리 내 하위 카테고리 목록 조회 성공"),
     GOODS_FIND_LIST_TOPCATEGORY_GOODS_AND_SUBCATEGORY(HttpStatus.OK, "상위 카테고리 내 상품과 하위 카테고리 목록 조회 성공"),
     GOODS_FIND_LIST_SUBCATEGORYLIST_GOODS_SUCCESS(HttpStatus.OK, "하위 카테고리 내 상품 목록 조회 성공"),
-    GOODS_FIND_LIST_INCREASE_RATE_SUCCESS(HttpStatus.OK, "매출 상승된 상품 목록 조회 성공"),
 
+    // 매출
+    GOODS_FIND_LIST_RATE_SUCCESS(HttpStatus.OK, "매출률 상품 목록 조회 성공"),
 
     // 템플릿(template)
     TEMPLATE_FIND_LIST_SUCCESS(HttpStatus.OK, "템플릿 목록 조회 성공"),

--- a/src/main/java/com/beauty4u/backend/common/success/SuccessCode.java
+++ b/src/main/java/com/beauty4u/backend/common/success/SuccessCode.java
@@ -38,6 +38,7 @@ public enum SuccessCode {
     GOODS_FIND_LIST_SUBCATEGORYLIST_SUCCESS(HttpStatus.OK, "상위 카테고리 내 하위 카테고리 목록 조회 성공"),
     GOODS_FIND_LIST_TOPCATEGORY_GOODS_AND_SUBCATEGORY(HttpStatus.OK, "상위 카테고리 내 상품과 하위 카테고리 목록 조회 성공"),
     GOODS_FIND_LIST_SUBCATEGORYLIST_GOODS_SUCCESS(HttpStatus.OK, "하위 카테고리 내 상품 목록 조회 성공"),
+    GOODS_FIND_LIST_INCREASE_RATE_SUCCESS(HttpStatus.OK, "매출 상승된 상품 목록 조회 성공"),
 
 
     // 템플릿(template)

--- a/src/main/java/com/beauty4u/backend/goods_rate/query/controller/GoodsRateQueryController.java
+++ b/src/main/java/com/beauty4u/backend/goods_rate/query/controller/GoodsRateQueryController.java
@@ -1,10 +1,11 @@
 package com.beauty4u.backend.goods_rate.query.controller;
 
+import com.beauty4u.backend.common.aggregate.PeriodType;
 import com.beauty4u.backend.common.response.ApiResponse;
 import com.beauty4u.backend.common.response.ResponseUtil;
 import com.beauty4u.backend.common.success.SuccessCode;
-import com.beauty4u.backend.goods.query.dto.GoodsQueryDTO;
 import com.beauty4u.backend.goods_rate.query.dto.GoodsRateQueryDTO;
+import com.beauty4u.backend.goods_rate.query.dto.GoodsRateResDTO;
 import com.beauty4u.backend.goods_rate.query.service.GoodsRateQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -12,25 +13,49 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/goodsRate")
-@Tag(name="GoodsRate", description = "상품 매출 조회 API")
+@Tag(name = "GoodsRate", description = "상품 매출 조회 API")
 public class GoodsRateQueryController {
 
     private final GoodsRateQueryService goodsRateQueryService;
 
-    @Operation(summary = "매출 상승률 조회", description = "메인 화면 매출 상승률을 조회한다.")
+    @Operation(summary = "일일 매출률 조회", description = "메인 화면 일일 매출 상승,하강률을 조회한다.")
     @GetMapping("/list")
-    public ResponseEntity<ApiResponse<List<GoodsRateQueryDTO>>> findGoodsRateIncrease() {
+    public ResponseEntity<ApiResponse<GoodsRateResDTO>> findGoodsRate(@RequestParam PeriodType periodType) {
+        LocalDateTime endDate = LocalDateTime.now().withHour(23).withMinute(59).withSecond(59);
+        LocalDateTime startDate = calculateStartDate(periodType, endDate).withHour(0).withMinute(0).withSecond(0);
 
-        List<GoodsRateQueryDTO> goodsRateList = goodsRateQueryService.findGoodsRateIncrease();
+        List<GoodsRateQueryDTO> goodsRateList = goodsRateQueryService.findGoodsRate(startDate, endDate, periodType);
 
-        return ResponseUtil.successResponse(SuccessCode.GOODS_FIND_LIST_INCREASE_RATE_SUCCESS, goodsRateList);
+        GoodsRateResDTO goodsRateResDTO = GoodsRateResDTO.builder()
+                .increase(goodsRateList.stream()
+                        .filter(rate -> "INCREASE".equals(rate.getRateType()))
+                        .collect(Collectors.toList()))
+                .decrease(goodsRateList.stream()
+                        .filter(rate -> "DECREASE".equals(rate.getRateType()))
+                        .collect(Collectors.toList()))
+                .build();
+
+        return ResponseUtil.successResponse(SuccessCode.GOODS_FIND_LIST_RATE_SUCCESS, goodsRateResDTO);
     }
 
+    private LocalDateTime calculateStartDate(PeriodType periodType, LocalDateTime endDate) {
+        return switch (periodType) {
+            case DAILY -> endDate.minusDays(1);
+            case WEEKLY -> endDate.minusWeeks(1);
+            case MONTHLY -> endDate.minusMonths(1);
+            case QUARTER -> endDate.minusMonths(3);
+            case HALF -> endDate.minusMonths(6);
+            case YEARLY -> endDate.minusYears(1);
+        };
+    }
 }

--- a/src/main/java/com/beauty4u/backend/goods_rate/query/controller/GoodsRateQueryController.java
+++ b/src/main/java/com/beauty4u/backend/goods_rate/query/controller/GoodsRateQueryController.java
@@ -1,0 +1,36 @@
+package com.beauty4u.backend.goods_rate.query.controller;
+
+import com.beauty4u.backend.common.response.ApiResponse;
+import com.beauty4u.backend.common.response.ResponseUtil;
+import com.beauty4u.backend.common.success.SuccessCode;
+import com.beauty4u.backend.goods.query.dto.GoodsQueryDTO;
+import com.beauty4u.backend.goods_rate.query.dto.GoodsRateQueryDTO;
+import com.beauty4u.backend.goods_rate.query.service.GoodsRateQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/goodsRate")
+@Tag(name="GoodsRate", description = "상품 매출 조회 API")
+public class GoodsRateQueryController {
+
+    private final GoodsRateQueryService goodsRateQueryService;
+
+    @Operation(summary = "매출 상승률 조회", description = "메인 화면 매출 상승률을 조회한다.")
+    @GetMapping("/list")
+    public ResponseEntity<ApiResponse<List<GoodsRateQueryDTO>>> findGoodsRateIncrease() {
+
+        List<GoodsRateQueryDTO> goodsRateList = goodsRateQueryService.findGoodsRateIncrease();
+
+        return ResponseUtil.successResponse(SuccessCode.GOODS_FIND_LIST_INCREASE_RATE_SUCCESS, goodsRateList);
+    }
+
+}

--- a/src/main/java/com/beauty4u/backend/goods_rate/query/dto/GoodsRateQueryDTO.java
+++ b/src/main/java/com/beauty4u/backend/goods_rate/query/dto/GoodsRateQueryDTO.java
@@ -10,9 +10,8 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 public class GoodsRateQueryDTO {
-    private String orderDate;
-    private String goodsCode;
     private String goodsName;
     private String brandName;
-    private String increaseRate;
+    private String rateChange;
+    private String rateType;
 }

--- a/src/main/java/com/beauty4u/backend/goods_rate/query/dto/GoodsRateQueryDTO.java
+++ b/src/main/java/com/beauty4u/backend/goods_rate/query/dto/GoodsRateQueryDTO.java
@@ -1,0 +1,18 @@
+package com.beauty4u.backend.goods_rate.query.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class GoodsRateQueryDTO {
+    private String orderDate;
+    private String goodsCode;
+    private String goodsName;
+    private String brandName;
+    private String increaseRate;
+}

--- a/src/main/java/com/beauty4u/backend/goods_rate/query/dto/GoodsRateResDTO.java
+++ b/src/main/java/com/beauty4u/backend/goods_rate/query/dto/GoodsRateResDTO.java
@@ -1,0 +1,15 @@
+package com.beauty4u.backend.goods_rate.query.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class GoodsRateResDTO {
+    private List<GoodsRateQueryDTO> increase;
+    private List<GoodsRateQueryDTO> decrease;
+}

--- a/src/main/java/com/beauty4u/backend/goods_rate/query/mapper/GoodsRateQueryMapper.java
+++ b/src/main/java/com/beauty4u/backend/goods_rate/query/mapper/GoodsRateQueryMapper.java
@@ -1,0 +1,11 @@
+package com.beauty4u.backend.goods_rate.query.mapper;
+
+import com.beauty4u.backend.goods_rate.query.dto.GoodsRateQueryDTO;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface GoodsRateQueryMapper {
+    List<GoodsRateQueryDTO> findGoodsRateIncrease();
+}

--- a/src/main/java/com/beauty4u/backend/goods_rate/query/mapper/GoodsRateQueryMapper.java
+++ b/src/main/java/com/beauty4u/backend/goods_rate/query/mapper/GoodsRateQueryMapper.java
@@ -2,10 +2,16 @@ package com.beauty4u.backend.goods_rate.query.mapper;
 
 import com.beauty4u.backend.goods_rate.query.dto.GoodsRateQueryDTO;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Mapper
 public interface GoodsRateQueryMapper {
-    List<GoodsRateQueryDTO> findGoodsRateIncrease();
+    List<GoodsRateQueryDTO> findGoodsRate(
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate,
+            @Param("periodType") String periodType
+    );
 }

--- a/src/main/java/com/beauty4u/backend/goods_rate/query/service/GoodsRateQueryService.java
+++ b/src/main/java/com/beauty4u/backend/goods_rate/query/service/GoodsRateQueryService.java
@@ -1,0 +1,21 @@
+package com.beauty4u.backend.goods_rate.query.service;
+
+import com.beauty4u.backend.goods_rate.query.dto.GoodsRateQueryDTO;
+import com.beauty4u.backend.goods_rate.query.mapper.GoodsRateQueryMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class GoodsRateQueryService {
+
+    private final GoodsRateQueryMapper goodsRateQueryMapper;
+
+    public List<GoodsRateQueryDTO> findGoodsRateIncrease() {
+        return goodsRateQueryMapper.findGoodsRateIncrease();
+    }
+}

--- a/src/main/java/com/beauty4u/backend/goods_rate/query/service/GoodsRateQueryService.java
+++ b/src/main/java/com/beauty4u/backend/goods_rate/query/service/GoodsRateQueryService.java
@@ -1,11 +1,16 @@
 package com.beauty4u.backend.goods_rate.query.service;
 
+import com.beauty4u.backend.common.aggregate.PeriodType;
 import com.beauty4u.backend.goods_rate.query.dto.GoodsRateQueryDTO;
+import com.beauty4u.backend.goods_rate.query.dto.GoodsRateResDTO;
 import com.beauty4u.backend.goods_rate.query.mapper.GoodsRateQueryMapper;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -13,9 +18,16 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class GoodsRateQueryService {
 
+    private static final Logger log = LoggerFactory.getLogger(GoodsRateQueryService.class);
     private final GoodsRateQueryMapper goodsRateQueryMapper;
 
-    public List<GoodsRateQueryDTO> findGoodsRateIncrease() {
-        return goodsRateQueryMapper.findGoodsRateIncrease();
+    public List<GoodsRateQueryDTO> findGoodsRate(LocalDateTime startDate, LocalDateTime endDate, PeriodType periodType) {
+
+//        return goodsRateQueryMapper.findGoodsRate(startDate, endDate, periodType.name());
+
+        log.info("조회 시작 - startDate: {}, endDate: {}, periodType: {}", startDate, endDate, periodType);
+        List<GoodsRateQueryDTO> result = goodsRateQueryMapper.findGoodsRate(startDate, endDate, periodType.name());
+        log.info("조회 결과 크기: {}", result.size());
+        return result;
     }
 }

--- a/src/main/resources/mapper/goods/GoodsRateMapper.xml
+++ b/src/main/resources/mapper/goods/GoodsRateMapper.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.beauty4u.backend.goods_rate.query.mapper.GoodsRateQueryMapper">
+    <select id="findGoodsRateIncrease" resultType="GoodsRateQueryDTO">
+        WITH
+        goods_allsales AS (
+        SELECT
+        o.created_date AS oneday,
+        o.goods_code,
+        g.goods_name,
+        b.brand_name,
+        SUM(o.order_count * o.order_price) AS daily_sales
+        FROM order_info o
+        JOIN goods g ON (o.goods_code = g.goods_code)
+        JOIN brand b ON (g.brand_code = b.brand_code)
+        GROUP BY o.goods_code, o.created_date, g.goods_name
+        ),
+        rate_growth AS (
+        SELECT
+        a.goods_code,
+        a.oneday,
+        a.goods_name,
+        b.brand_name,
+        a.daily_sales AS current_sales,
+        b.daily_sales AS previous_sales,
+        CASE
+        WHEN b.daily_sales IS NOT NULL AND b.daily_sales != 0
+        THEN CONCAT(
+        ROUND(((a.daily_sales - b.daily_sales) / b.daily_sales) * 100,2),
+        '% (',
+        FORMAT(b.daily_sales, 0),
+        '원 → ',
+        FORMAT(a.daily_sales, 0),
+        '원)'
+        )
+        ELSE NULL
+        END AS increaseRate
+        FROM goods_allsales a
+        LEFT JOIN goods_allsales b ON a.goods_code = b.goods_code
+        AND b.oneday = DATE_SUB(a.oneday, INTERVAL 1 DAY)
+        )
+        SELECT
+        DATE_FORMAT(oneday, '%Y-%m-%d') AS orderDate,
+        goods_code AS goodsCode,
+        goods_name AS goodsName,
+        brand_name AS brandName,
+        increaseRate
+        FROM rate_growth
+        WHERE increaseRate > 0
+        <if test="startDate != null">
+            AND oneday >= #{startDate}
+        </if>
+        <if test="endDate != null">
+            CAST(SUBSTRING_INDEX(increaseRate, '%', 1) AS DECIMAL(10,2)) DESC
+        </if>
+        ORDER BY increaseRate DESC
+        LIMIT 5
+    </select>
+</mapper>

--- a/src/main/resources/mapper/goods/GoodsRateMapper.xml
+++ b/src/main/resources/mapper/goods/GoodsRateMapper.xml
@@ -1,59 +1,104 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.beauty4u.backend.goods_rate.query.mapper.GoodsRateQueryMapper">
-    <select id="findGoodsRateIncrease" resultType="GoodsRateQueryDTO">
+    <select id="findGoodsRate" resultType="GoodsRateQueryDTO">
         WITH
-        goods_allsales AS (
+        current_period_sales AS (
+        <!--        현재 기간 매출 합계 -->
         SELECT
-        o.created_date AS oneday,
         o.goods_code,
         g.goods_name,
         b.brand_name,
-        SUM(o.order_count * o.order_price) AS daily_sales
+        SUM(o.order_count * o.order_price) as current_sales
         FROM order_info o
-        JOIN goods g ON (o.goods_code = g.goods_code)
-        JOIN brand b ON (g.brand_code = b.brand_code)
-        GROUP BY o.goods_code, o.created_date, g.goods_name
+        JOIN goods g ON o.goods_code = g.goods_code
+        JOIN brand b ON g.brand_code = b.brand_code
+        WHERE o.order_status = 'PURCHASED'
+        AND DATE(o.created_date) BETWEEN
+        CASE #{periodType}
+        WHEN 'DAILY' THEN DATE(#{endDate})
+        WHEN 'WEEKLY' THEN DATE_SUB(DATE(#{endDate}), INTERVAL 6 DAY)
+        WHEN 'MONTHLY' THEN DATE_SUB(DATE(#{endDate}), INTERVAL 29 DAY)
+        WHEN 'QUARTER' THEN DATE_SUB(DATE(#{endDate}), INTERVAL 89 DAY)
+        WHEN 'HALF' THEN DATE_SUB(DATE(#{endDate}), INTERVAL 179 DAY)
+        WHEN 'YEARLY' THEN DATE_SUB(DATE(#{endDate}), INTERVAL 364 DAY)
+        END
+        AND DATE(#{endDate})
+        GROUP BY o.goods_code, g.goods_name, b.brand_name
         ),
-        rate_growth AS (
+        <!--        이전 기간 매출 합계 -->
+        previous_period_sales AS
+        (
         SELECT
-        a.goods_code,
-        a.oneday,
-        a.goods_name,
-        b.brand_name,
-        a.daily_sales AS current_sales,
-        b.daily_sales AS previous_sales,
-        CASE
-        WHEN b.daily_sales IS NOT NULL AND b.daily_sales != 0
-        THEN CONCAT(
-        ROUND(((a.daily_sales - b.daily_sales) / b.daily_sales) * 100,2),
+        o.goods_code,
+        SUM(o.order_count * o.order_price) as previous_sales
+        FROM order_info o
+        WHERE o.order_status = 'PURCHASED'
+        AND DATE(o.created_date) BETWEEN
+        CASE #{periodType}
+        WHEN 'DAILY' THEN DATE_SUB(DATE(#{endDate}), INTERVAL 1 DAY)
+        WHEN 'WEEKLY' THEN DATE_SUB(DATE(#{endDate}), INTERVAL 13 DAY)
+        WHEN 'MONTHLY' THEN DATE_SUB(DATE(#{endDate}), INTERVAL 50 DAY)
+        WHEN 'QUARTER' THEN DATE_SUB(DATE(#{endDate}), INTERVAL 179 DAY)
+        WHEN 'HALF' THEN DATE_SUB(DATE(#{endDate}), INTERVAL 359 DAY)
+        WHEN 'YEARLY' THEN DATE_SUB(DATE(#{endDate}), INTERVAL 729 DAY)
+        END
+        AND
+        CASE #{periodType}
+        WHEN 'DAILY' THEN DATE_SUB(DATE(#{endDate}), INTERVAL 1 DAY)
+        WHEN 'WEEKLY' THEN DATE_SUB(DATE(#{endDate}), INTERVAL 7 DAY)
+        WHEN 'MONTHLY' THEN DATE_SUB(DATE(#{endDate}), INTERVAL 30 DAY)
+        WHEN 'QUARTER' THEN DATE_SUB(DATE(#{endDate}), INTERVAL 90 DAY)
+        WHEN 'HALF' THEN DATE_SUB(DATE(#{endDate}), INTERVAL 180 DAY)
+        WHEN 'YEARLY' THEN DATE_SUB(DATE(#{endDate}), INTERVAL 365 DAY)
+        END
+        GROUP BY o.goods_code
+        ),
+        rate_calc AS
+        (
+        SELECT
+        c.goods_code,
+        c.goods_name,
+        c.brand_name,
+        c.current_sales,
+        p.previous_sales,
+        ((c.current_sales - p.previous_sales) / p.previous_sales * 100) as rate_value,
+        CONCAT(
+        ROUND(((c.current_sales - p.previous_sales) / p.previous_sales * 100), 2),
         '% (',
-        FORMAT(b.daily_sales, 0),
+        FORMAT(p.previous_sales, 0),
         '원 → ',
-        FORMAT(a.daily_sales, 0),
+        FORMAT(c.current_sales, 0),
         '원)'
+        ) as rate_change
+        FROM current_period_sales c
+        INNER JOIN previous_period_sales p ON c.goods_code = p.goods_code
+        WHERE p.previous_sales >= 0
         )
-        ELSE NULL
-        END AS increaseRate
-        FROM goods_allsales a
-        LEFT JOIN goods_allsales b ON a.goods_code = b.goods_code
-        AND b.oneday = DATE_SUB(a.oneday, INTERVAL 1 DAY)
-        )
-        SELECT
-        DATE_FORMAT(oneday, '%Y-%m-%d') AS orderDate,
-        goods_code AS goodsCode,
+        SELECT * FROM (
+        <!--        상승률 TOP 5-->
+        (SELECT
         goods_name AS goodsName,
         brand_name AS brandName,
-        increaseRate
-        FROM rate_growth
-        WHERE increaseRate > 0
-        <if test="startDate != null">
-            AND oneday >= #{startDate}
-        </if>
-        <if test="endDate != null">
-            CAST(SUBSTRING_INDEX(increaseRate, '%', 1) AS DECIMAL(10,2)) DESC
-        </if>
-        ORDER BY increaseRate DESC
-        LIMIT 5
+        rate_change AS rateChange,
+        'INCREASE' AS rateType
+        FROM rate_calc
+        WHERE rate_value > 0
+        ORDER BY rate_value DESC
+        LIMIT 5)
+
+        UNION ALL
+
+        <!--         하락률 TOP 5-->
+        (SELECT
+        goods_name AS goodsName,
+        brand_name AS brandName,
+        rate_change AS rateChange,
+        'DECREASE' AS rateType
+        FROM rate_calc
+        WHERE rate_value &lt; 0
+        ORDER BY rate_value ASC
+        LIMIT 5)
+        ) result
     </select>
 </mapper>


### PR DESCRIPTION
🌟개요
---
날짜별 상품 매출 증가, 하락률을 구현하였습니다

🌐연결된 Issues
---
Closes #232 

📋작업사항
---
1일, 7일, 30일, 3개월, 6개월, 1년 선택 시 해당 날짜에 구매 이력이 있는 상품별 매출 증가, 하락률을 구현하였습니다.

✏️작성한 이슈 외 작업사항
---
- 엘라스틱 서치 도커 포트를 수정하였습니다.
- **일일 날짜 비교는 아직 미완성입니다.**

✅체크리스트
---
- [ ] PR 규칙을 준수하였는가?
- [ ] 이슈번호를 작성하였는가?
- [ ] 추가/수정 사항을 설명하였는가?
