### PR TITLE
feat: 채팅 컨트롤러 통합 및 DB 조회 최적화

### DIFF
--- a/src/main/java/com/beauty4u/backend/common/success/SuccessCode.java
+++ b/src/main/java/com/beauty4u/backend/common/success/SuccessCode.java
@@ -145,6 +145,16 @@ public enum SuccessCode {
     FOLDER_LIST_FIND_SUCCESS(HttpStatus.OK, "폴더 목록 조회 성공"),
     FOLDER_DELETE_SUCCESS(HttpStatus.OK, "폴더 삭제 성공"),
 
+    // 채팅 메세지
+    CHAT_SEND_SUCCESS(HttpStatus.CREATED, "채팅 메세지 전송 성공"),
+    CHAT_FIND_SUCCESS(HttpStatus.OK, "채팅 메세지 조회 성공"),
+
+    // 팀스페이스
+    TEAMSPACE_SAVE_SUCCESS(HttpStatus.CREATED, "팀스페이스 생성 성공"),
+    TEAMSPACE_SAVE_ALL_SUCCESS(HttpStatus.CREATED, "부서별 팀스페이스 생성 성공"),
+    TEAMSPACE_FIND_DEPTCODE_SUCCESS(HttpStatus.CREATED, "부서별 팀스페이스 생성 성공"),
+    TEAMSPACE_CHAT_FIND_DETAIL_SUCCESS(HttpStatus.OK, "팀스페이스 채팅 상세조회 성공"),
+    
     // 팀 게시판 (teamspace)
     TEAMBOARD_SAVE_SUCCESS(HttpStatus.CREATED, "팀 게시판 글 등록 성공"),
     TEAMBOARD_UPDATE_SUCCESS(HttpStatus.OK, "팀 게시판 글 수정 성공"),

--- a/src/main/java/com/beauty4u/backend/teamspace/command/application/controller/ChatCommandController.java
+++ b/src/main/java/com/beauty4u/backend/teamspace/command/application/controller/ChatCommandController.java
@@ -2,7 +2,6 @@ package com.beauty4u.backend.teamspace.command.application.controller;
 
 import com.beauty4u.backend.teamspace.command.application.dto.chat.ChatMessageReqDto;
 import com.beauty4u.backend.teamspace.command.application.service.ChatService;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
@@ -19,8 +18,7 @@ public class ChatCommandController {
     // 웹소켓 메세지를 특정 경로로 매핑한다.
     @MessageMapping("/{teamspaceId}") // /pub/1
     public void sendMessage(@DestinationVariable(value = "teamspaceId") Long teamspaceId,
-                            ChatMessageReqDto chatMessageReqDto)
-                            throws JsonProcessingException {
+                            ChatMessageReqDto chatMessageReqDto) {
         chatService.sendMessage(teamspaceId, chatMessageReqDto);
     }
 }

--- a/src/main/java/com/beauty4u/backend/teamspace/command/application/controller/TeamSpaceCommandController.java
+++ b/src/main/java/com/beauty4u/backend/teamspace/command/application/controller/TeamSpaceCommandController.java
@@ -1,11 +1,13 @@
 package com.beauty4u.backend.teamspace.command.application.controller;
 
+import com.beauty4u.backend.common.response.ApiResponse;
+import com.beauty4u.backend.common.response.ResponseUtil;
+import com.beauty4u.backend.common.success.SuccessCode;
 import com.beauty4u.backend.teamspace.command.application.service.TeamSpaceService;
 import com.beauty4u.backend.teamspace.command.domain.aggregate.Teamspace;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,15 +23,15 @@ public class TeamSpaceCommandController {
 
     @PostMapping("/create")
     @Operation(summary = "팀스페이스 생성", description = "팀스페이스를 생성한다.")
-    public ResponseEntity<Void> createTeamSpace(@RequestParam String deptCode) {
+    public ResponseEntity<ApiResponse<Void>> createTeamSpace(@RequestParam String deptCode) {
         Teamspace teamspace =  teamSpaceService.createTeamspace(deptCode);
-        return ResponseEntity.status(HttpStatus.CREATED).build();  // 본문 없이 상태 코드만 반환
+        return ResponseUtil.successResponse(SuccessCode.TEAMSPACE_SAVE_SUCCESS);
     }
 
     @PostMapping("/initialize")
     @Operation(summary = "부서별 팀스페이스 생성", description = "부서별 초기 팀스페이스를 생성한다.")
-    public ResponseEntity<Void> initializeCreateTeamSpace() {
+    public ResponseEntity<ApiResponse<Void>> initializeCreateTeamSpace() {
         List<Teamspace> teamspaces = teamSpaceService.createAndAssignTeamSpaces();
-        return ResponseEntity.status(HttpStatus.CREATED).build();  // 본문 없이 상태 코드만 반환
+        return ResponseUtil.successResponse(SuccessCode.TEAMSPACE_SAVE_ALL_SUCCESS);
     }
 }

--- a/src/main/java/com/beauty4u/backend/teamspace/command/application/dto/chat/ChatMessageReqDto.java
+++ b/src/main/java/com/beauty4u/backend/teamspace/command/application/dto/chat/ChatMessageReqDto.java
@@ -12,6 +12,7 @@ import java.time.ZonedDateTime;
 public class ChatMessageReqDto {
 
     private String userCode; // senderId 변경
+    private String userName;
     private String messageContent;
     private ZonedDateTime messageCreatedTime;
 

--- a/src/main/java/com/beauty4u/backend/teamspace/command/application/service/ChatService.java
+++ b/src/main/java/com/beauty4u/backend/teamspace/command/application/service/ChatService.java
@@ -2,15 +2,11 @@ package com.beauty4u.backend.teamspace.command.application.service;
 
 import com.beauty4u.backend.teamspace.command.application.dto.chat.ChatMessageReqDto;
 import com.beauty4u.backend.teamspace.command.domain.aggregate.ChatMessage;
-import com.beauty4u.backend.teamspace.command.domain.aggregate.Teamspace;
 import com.beauty4u.backend.teamspace.command.domain.repository.ChatMessageRepository;
-import com.beauty4u.backend.teamspace.command.domain.repository.TeamSpaceRepository;
-import com.beauty4u.backend.user.command.domain.aggregate.UserInfo;
-import com.beauty4u.backend.user.command.domain.repository.UserRepository;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -18,34 +14,31 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ChatService {
 
-    private final UserRepository userRepository;
-    private final TeamSpaceRepository teamSpaceRepository;
     private final ChatMessageRepository chatMessageRepository;
     private final SimpMessagingTemplate simpMessagingTemplate;
 
     public void sendMessage(Long teamspaceId, ChatMessageReqDto chatMessageReqDto) {
 
-        // 팀스페이스 찾기
-        Teamspace teamspace = teamSpaceRepository.findById(teamspaceId)
-                .orElseThrow(() -> new EntityNotFoundException("팀스페이스가 존재하지 않습니다."));
-
-        // 보낸 사람 찾기
-        UserInfo sender = userRepository.findByUserCode(chatMessageReqDto.getUserCode())
-                .orElseThrow(() -> new EntityNotFoundException("유저가 존재하지 않습니다."));
-
-
         // 메시지 생성 및 저장
         ChatMessage chatMessage = ChatMessage.builder()
                 .messageContent(chatMessageReqDto.getMessageContent())
-                .userCode(sender.getUserCode())
-                .teamspaceId(teamspace.getId())
+                .userCode(chatMessageReqDto.getUserCode())
+                .userName(chatMessageReqDto.getUserName())
+                .teamspaceId(teamspaceId)
                 .build();
 
-        chatMessageRepository.save(chatMessage);
+        // 비동기로 메시지 저장
+        saveMessageAsync(chatMessage);
 
         // STOMP 메시지 전송
         // 해당 주소를 수신하고 있는 유저들에게 보내짐
         simpMessagingTemplate.convertAndSend("/sub/teamspace/" + teamspaceId, chatMessageReqDto);
         log.info("Message [{}] saved and sent to destination [{}]", chatMessage.getMessageContent(), "/sub/teamspace/" + teamspaceId);
+    }
+
+    @Async
+    public void saveMessageAsync(ChatMessage chatMessage) {
+        chatMessageRepository.save(chatMessage);
+        log.info("Message [{}] saved to database", chatMessage.getMessageContent());
     }
 }

--- a/src/main/java/com/beauty4u/backend/teamspace/command/domain/aggregate/ChatMessage.java
+++ b/src/main/java/com/beauty4u/backend/teamspace/command/domain/aggregate/ChatMessage.java
@@ -26,10 +26,10 @@ public class ChatMessage{
 
     private String userCode; // sender 사용자 코드
 
-    private Long scrapId; // 스크랩 번호
+    private String userName;
 
     @Enumerated(value = EnumType.STRING)  // 몽고DB에서 기본적으로 문자열 처리를 해준다.
-    private MessageStatus messageStatus; // 메시지 상태 (ACTIVE, INACTIVE)
+    private MessageStatus messageStatus = MessageStatus.ACTIVE; // 메시지 상태 (ACTIVE, INACTIVE)
 
     @NotNull
     private String messageContent; // 메시지 내용

--- a/src/main/java/com/beauty4u/backend/teamspace/query/controller/ChatQueryController.java
+++ b/src/main/java/com/beauty4u/backend/teamspace/query/controller/ChatQueryController.java
@@ -1,6 +1,6 @@
 package com.beauty4u.backend.teamspace.query.controller;
 
-import com.beauty4u.backend.teamspace.command.domain.aggregate.ChatMessage;
+import com.beauty4u.backend.teamspace.query.dto.chatMessage.ChatMessageResDto;
 import com.beauty4u.backend.teamspace.query.service.ChatQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/vi")
+@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 @Tag(name = "ChatMessage", description = "채팅 관련 API")
 public class ChatQueryController {
@@ -21,9 +21,9 @@ public class ChatQueryController {
 
     @GetMapping("/teamspace/{teamspaceId}")
     @Operation(summary = "채팅 내역 조회", description = "팀스페이스 채팅 내역을 조회한다.")
-    public ResponseEntity<List<ChatMessage>> getChatHistory(@PathVariable Long teamspaceId) {
+    public ResponseEntity<List<ChatMessageResDto>> getChatHistory(@PathVariable Long teamspaceId) {
 
-        List<ChatMessage> chatMessages = chatQueryService.getChatHistory(teamspaceId);
+        List<ChatMessageResDto> chatMessages = chatQueryService.getChatHistory(teamspaceId);
         return new ResponseEntity<>(chatMessages, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/beauty4u/backend/teamspace/query/controller/TeamSpaceQueryController.java
+++ b/src/main/java/com/beauty4u/backend/teamspace/query/controller/TeamSpaceQueryController.java
@@ -1,10 +1,8 @@
 package com.beauty4u.backend.teamspace.query.controller;
 
-import com.beauty4u.backend.common.util.CustomUserUtil;
+import com.beauty4u.backend.teamspace.query.dto.teamspace.TeamSpaceDetailsDto;
 import com.beauty4u.backend.teamspace.query.dto.teamspace.TeamSpaceUserInfoDto;
 import com.beauty4u.backend.teamspace.query.service.TeamSpaceQueryService;
-import com.beauty4u.backend.user.query.dto.FindUserDetailResDTO;
-import com.beauty4u.backend.user.query.service.UserQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -13,15 +11,14 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/vi/teamspace")
+@RequestMapping("/api/v1/teamspace")
 @RequiredArgsConstructor
 @Tag(name = "TeamSpace", description = "팀스페이스 API")
 public class TeamSpaceQueryController {
 
-    private final UserQueryService userQueryService;
     private final TeamSpaceQueryService teamSpaceQueryService;
 
-    @Operation(summary = "내 팀스페이스 ID 조회", description = "본인이 속한 부서의 팀스페이스 ID를 조회한다.")
+    @Operation(summary = "팀스페이스 ID 조회", description = "부서 코드로 팀스페이스 ID를 조회한다.")
     @GetMapping("")
     public Long getMyTeamSpaceId(@RequestParam("deptCode") String deptCode) {
         return teamSpaceQueryService.getMyTeamSpaceIdByDeptCode(deptCode);
@@ -38,5 +35,12 @@ public class TeamSpaceQueryController {
     @GetMapping("/{teamspaceId}/dept")
     public String getDeptCodeByTeamspaceId(@PathVariable String teamspaceId) {
         return teamSpaceQueryService.getDeptCodeByTeamspaceId(teamspaceId);
+    }
+
+    // 팀스페이스 통합 컨트롤러
+    @Operation(summary = "팀스페이스 채팅 상세조회", description = "팀스페이스 채팅방 참여자, 채팅 목록을 조회합니다.")
+    @GetMapping("/{teamspaceId}/details")
+    public TeamSpaceDetailsDto getTeamSpaceDetails(@PathVariable Long teamspaceId, @RequestParam String deptCode) {
+        return teamSpaceQueryService.getTeamSpaceDetails(teamspaceId, deptCode);
     }
 }

--- a/src/main/java/com/beauty4u/backend/teamspace/query/dto/chatMessage/ChatMessageResDto.java
+++ b/src/main/java/com/beauty4u/backend/teamspace/query/dto/chatMessage/ChatMessageResDto.java
@@ -1,20 +1,17 @@
 package com.beauty4u.backend.teamspace.query.dto.chatMessage;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
-@Data
+@Setter
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 public class ChatMessageResDto {
-    private Long messageId;
+    private String messageId;
     private Long teamspaceId;
-//    private String userCode; // 메세지 발신자
-    private String senderName;
-    private String scarpId;
+    private String userCode;
+    private String userName; // 메세지 발신자
     private String messageStatus;
     private String messageContent;
     private String messageCreatedTime;

--- a/src/main/java/com/beauty4u/backend/teamspace/query/dto/teamspace/TeamSpaceDetailsDto.java
+++ b/src/main/java/com/beauty4u/backend/teamspace/query/dto/teamspace/TeamSpaceDetailsDto.java
@@ -1,0 +1,19 @@
+package com.beauty4u.backend.teamspace.query.dto.teamspace;
+
+import com.beauty4u.backend.teamspace.query.dto.chatMessage.ChatMessageResDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class TeamSpaceDetailsDto {
+    private String deptName;
+    private List<TeamSpaceUserInfoDto> participants;
+    private List<ChatMessageResDto> messages;
+}

--- a/src/main/java/com/beauty4u/backend/teamspace/query/service/ChatQueryService.java
+++ b/src/main/java/com/beauty4u/backend/teamspace/query/service/ChatQueryService.java
@@ -2,19 +2,62 @@ package com.beauty4u.backend.teamspace.query.service;
 
 import com.beauty4u.backend.teamspace.command.domain.aggregate.ChatMessage;
 import com.beauty4u.backend.teamspace.command.domain.repository.ChatMessageRepository;
+import com.beauty4u.backend.teamspace.query.dto.chatMessage.ChatMessageResDto;
+import com.beauty4u.backend.user.command.domain.aggregate.UserInfo;
+import com.beauty4u.backend.user.command.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class ChatQueryService {
 
     private final ChatMessageRepository chatMessageRepository;
+    private final UserRepository userRepository;
 
-    public List<ChatMessage> getChatHistory(Long teamspaceId) {
-
+    public List<ChatMessageResDto> getChatHistory(Long teamspaceId) {
+        // 1. 채팅 메세지 조회
         List<ChatMessage> chatMessages = chatMessageRepository.findByTeamspaceId(teamspaceId);
-        return chatMessages;
+
+        // 2. userCode 목록 추출 (중복 제거)
+        List<String> userCodes = chatMessages.stream()
+                .map(ChatMessage::getUserCode)
+                .distinct()
+                .toList();
+
+        // 3. UserRepository를 통해 유저 정보를 한 번에 로드
+        List<UserInfo> users = userRepository.findAllByUserCodeIn(userCodes);
+
+        // 4. userCode와 userName 매핑 (Map 생성)
+        Map<String, String> userCodeToNameMap = users.stream()
+                .collect(Collectors.toMap(UserInfo::getUserCode, UserInfo::getUserName));
+
+        // 5. 채팅 메시지와 사용자 이름 매핑
+        return chatMessages.stream()
+                .map(chatMessage -> {
+                    String userName = userCodeToNameMap.getOrDefault(chatMessage.getUserCode(), "알수 없음");
+                    return convertToDto(chatMessage, userName);
+                })
+                .toList();
+    }
+
+    private ChatMessageResDto convertToDto(ChatMessage chatMessage, String userName) {
+        ChatMessageResDto dto = new ChatMessageResDto();
+        dto.setMessageId(chatMessage.getId().toHexString());
+        dto.setTeamspaceId(chatMessage.getTeamspaceId());
+        dto.setUserCode(chatMessage.getUserCode());
+        dto.setUserName(userName); // 유저 이름 설정
+        dto.setMessageStatus(chatMessage.getMessageStatus().toString());
+        dto.setMessageContent(chatMessage.getMessageContent());
+        dto.setMessageCreatedTime(chatMessage.getMessageCreatedTime().toString());
+        dto.setMessageDeletedTime(
+                chatMessage.getMessageDeletedTime() != null
+                        ? chatMessage.getMessageDeletedTime().toString()
+                        : null
+        );
+        return dto;
     }
 }

--- a/src/main/java/com/beauty4u/backend/teamspace/query/service/TeamSpaceQueryService.java
+++ b/src/main/java/com/beauty4u/backend/teamspace/query/service/TeamSpaceQueryService.java
@@ -1,31 +1,105 @@
 package com.beauty4u.backend.teamspace.query.service;
 
+import com.beauty4u.backend.teamspace.command.domain.aggregate.ChatMessage;
+import com.beauty4u.backend.teamspace.command.domain.repository.ChatMessageRepository;
+import com.beauty4u.backend.teamspace.query.dto.chatMessage.ChatMessageResDto;
+import com.beauty4u.backend.teamspace.query.dto.teamspace.TeamSpaceDetailsDto;
 import com.beauty4u.backend.teamspace.query.dto.teamspace.TeamSpaceUserInfoDto;
 import com.beauty4u.backend.teamspace.query.mapper.TeamSpaceQueryMapper;
+import com.beauty4u.backend.user.command.domain.aggregate.UserInfo;
+import com.beauty4u.backend.user.command.domain.repository.UserRepository;
+import com.beauty4u.backend.user.query.mapper.DeptQueryMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
-@Transactional(readOnly = true)
 public class TeamSpaceQueryService {
 
     private final TeamSpaceQueryMapper teamSpaceQueryMapper;
+    private final DeptQueryMapper deptQueryMapper;
+    private final UserRepository userRepository;
+    private final ChatMessageRepository chatMessageRepository;
 
     // 부서 코드로 채팅참여자 정보 조회
+    @Transactional(readOnly = true)
     public List<TeamSpaceUserInfoDto> findAllTeamSpaceUser(String deptCode) {
         return teamSpaceQueryMapper.findAllTeamSpaceUser(deptCode);
     }
 
     // 팀스페이스 id로 부서 코드 조회
+    @Transactional(readOnly = true)
     public String getDeptCodeByTeamspaceId(String teamspaceId) {
         return teamSpaceQueryMapper.findTeamSpaceDeptCode(teamspaceId);
     }
 
     // 부서 코드로 팀스페이스 id 조회
+    @Transactional(readOnly = true)
     public Long getMyTeamSpaceIdByDeptCode(String deptCode) {
         return teamSpaceQueryMapper.findTeamSpaceId(deptCode);
+    }
+
+    // 팀스페이스 세부 정보 조회
+    @Transactional(readOnly = true)
+    public TeamSpaceDetailsDto getTeamSpaceDetails(Long teamspaceId, String deptCode) {
+        // 1. 부서 이름 조회
+        String deptName = getDeptNameByCode(deptCode);
+
+        // 2. 참여자 정보 조회
+        List<TeamSpaceUserInfoDto> participants = findAllTeamSpaceUser(deptCode);
+
+        // 3. 채팅 메시지와 사용자 이름 매핑
+        List<ChatMessageResDto> messages = getChatMessagesWithUserNames(teamspaceId);
+
+        return new TeamSpaceDetailsDto(deptName, participants, messages);
+    }
+
+    private String getDeptNameByCode(String deptCode) {
+        return deptQueryMapper.findDeptName(deptCode).getDeptName();
+    }
+
+    private List<ChatMessageResDto> getChatMessagesWithUserNames(Long teamspaceId) {
+        // 1. 채팅 메시지 조회
+        List<ChatMessage> chatMessages = chatMessageRepository.findByTeamspaceId(teamspaceId);
+
+        // 2. userCode 목록 추출 및 유저 정보 조회
+        Map<String, String> userCodeToNameMap = getUserCodeToNameMap(
+                chatMessages.stream()
+                        .map(ChatMessage::getUserCode)
+                        .distinct()
+                        .toList()
+        );
+
+        // 3. 채팅 메시지와 사용자 이름 매핑
+        return chatMessages.stream()
+                .map(chatMessage -> {
+                    String userName = userCodeToNameMap.getOrDefault(chatMessage.getUserCode(), "알수 없음");
+                    return convertToDto(chatMessage, userName);
+                })
+                .toList();
+    }
+
+    private Map<String, String> getUserCodeToNameMap(List<String> userCodes) {
+        return userRepository.findAllByUserCodeIn(userCodes).stream()
+                .collect(Collectors.toMap(UserInfo::getUserCode, UserInfo::getUserName));
+    }
+
+    private ChatMessageResDto convertToDto(ChatMessage chatMessage, String userName) {
+        return ChatMessageResDto.builder()
+                .messageId(chatMessage.getId().toHexString())
+                .teamspaceId(chatMessage.getTeamspaceId())
+                .userCode(chatMessage.getUserCode())
+                .userName(userName)
+                .messageStatus(chatMessage.getMessageStatus().toString())
+                .messageContent(chatMessage.getMessageContent())
+                .messageCreatedTime(chatMessage.getMessageCreatedTime().toString())
+                .messageDeletedTime(chatMessage.getMessageDeletedTime() != null
+                        ? chatMessage.getMessageDeletedTime().toString()
+                        : null)
+                .build();
     }
 }

--- a/src/main/java/com/beauty4u/backend/user/command/domain/repository/UserRepository.java
+++ b/src/main/java/com/beauty4u/backend/user/command/domain/repository/UserRepository.java
@@ -1,19 +1,21 @@
 package com.beauty4u.backend.user.command.domain.repository;
 
 import com.beauty4u.backend.user.command.domain.aggregate.UserInfo;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<UserInfo, String> {
 
+    @EntityGraph(attributePaths = {"jobCode", "deptCode","userRole"})
     Optional<UserInfo> findByUserCode(String userCode);
 
     Optional<UserInfo> findByUserNameAndPhoneAndEmail(String userName, String phone, String email);
 
     boolean existsByUserCodeAndUserNameAndEmail(String userCode, String name, String email);
 
+    @EntityGraph(attributePaths = {"jobCode", "deptCode","userRole"})
     List<UserInfo> findAllByUserCodeIn(Collection<String> userCodes);
 }

--- a/src/main/java/com/beauty4u/backend/user/query/controller/UserQueryController.java
+++ b/src/main/java/com/beauty4u/backend/user/query/controller/UserQueryController.java
@@ -62,6 +62,15 @@ public class UserQueryController {
         return ResponseUtil.successResponse(SuccessCode.DEPT_READ_SUCCESS, deptResDTOS);
     }
 
+    @Operation(summary = "부서 이름 조회")
+    @GetMapping("/dept")
+    public ResponseEntity<ApiResponse<DeptResDTO>> findDeptName(@RequestParam String deptCode) {
+
+        DeptResDTO deptResDTO = userQueryService.findDeptName(deptCode);
+
+        return ResponseUtil.successResponse(SuccessCode.DEPT_READ_SUCCESS, deptResDTO);
+    }
+
     @Operation(summary = "직급 목록 조회")
     @GetMapping("/job/list")
     public ResponseEntity<ApiResponse<List<JobResDTO>>> findJobList() {

--- a/src/main/java/com/beauty4u/backend/user/query/mapper/DeptQueryMapper.java
+++ b/src/main/java/com/beauty4u/backend/user/query/mapper/DeptQueryMapper.java
@@ -9,4 +9,6 @@ import java.util.List;
 public interface DeptQueryMapper {
 
     List<DeptResDTO> findDeptList();
+
+    DeptResDTO findDeptName(String deptCode);
 }

--- a/src/main/java/com/beauty4u/backend/user/query/service/UserQueryService.java
+++ b/src/main/java/com/beauty4u/backend/user/query/service/UserQueryService.java
@@ -49,6 +49,11 @@ public class UserQueryService {
     }
 
     @Transactional(readOnly = true)
+    public DeptResDTO findDeptName(String deptCode) {
+        return deptQueryMapper.findDeptName(deptCode);
+    }
+
+    @Transactional(readOnly = true)
     public List<JobResDTO> findJobList() {
 
         return jobQueryMapper.findJobList();

--- a/src/main/resources/mapper/user/DeptMapper.xml
+++ b/src/main/resources/mapper/user/DeptMapper.xml
@@ -8,4 +8,12 @@
             dept_name
         FROM dept
     </select>
+
+    <select id="findDeptName" resultType="DeptResDTO">
+        SELECT
+        dept_code,
+        dept_name
+        FROM dept
+        WHERE dept_code = #{dept_code}
+    </select>
 </mapper>


### PR DESCRIPTION
🌟개요
---

🌐연결된 Issues
---
Closes #235 

📋작업사항
--- 프론트에서 채팅 정보 조회를 한번에 요청 가능하도록 컨트롤러를 통합했습니다(기존 레거시 컨트롤러는 존재).
--- 채팅 전송시 DB 조회하던 로직을 삭제했습니다.
--- 채팅 내역 조회시 DB 조회를 줄였습니다.
--- userCode로 유저 정보 조회시 다중 SELECT문을 @EntitiyGraph를 사용해 JOIN문을 사용한 단일 조회로 수정했습니다.
--- 실시간 채팅시 채팅 상대방의 이름을 표시하기 위해 DTO를 추가했습니다.


