### PR TITLE
Feat: 프로모션 알림 이메일 발송 기능 구현

### DIFF
--- a/src/main/java/com/beauty4u/backend/common/util/MailUtil.java
+++ b/src/main/java/com/beauty4u/backend/common/util/MailUtil.java
@@ -1,16 +1,53 @@
 package com.beauty4u.backend.common.util;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
+import java.util.concurrent.CompletableFuture;
+
 @Service
-@RequiredArgsConstructor
 public class MailUtil {
 
-    private final JavaMailSender mailSender;
+    private final JavaMailSender fakeMailSender;
+    private final JavaMailSender gmailMailSender;
 
+    public MailUtil(
+            @Qualifier("fakeMailSender") JavaMailSender fakeMailSender,
+            @Qualifier("gmailMailSender") JavaMailSender gmailMailSender
+    ) {
+        this.fakeMailSender = fakeMailSender;
+        this.gmailMailSender = gmailMailSender;
+    }
+
+    /* fakeSMTP 사용 - 테스트 시 사용 */
+    @Async
+    public CompletableFuture<Void> sendPromotionFakeSmtpAsync(String email, String title, String body) {
+        return CompletableFuture.runAsync(() -> {
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setTo(email);
+            message.setSubject(title);
+            message.setText(body);
+            fakeMailSender.send(message);
+        });
+    }
+
+    /* Gmail 사용 - 시현시 사용 3개의 이메일 주소로 발송 */
+    @Async
+    public CompletableFuture<Void> sendPromotionGmailAsync(String email, String title, String body) {
+        return CompletableFuture.runAsync(() -> {
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setTo(email);
+            message.setSubject(title);
+            message.setText(body);
+            gmailMailSender.send(message);
+        });
+    }
+
+    /* 설빈 구축 메소드 Gmail 사용변경 */
     public void sendEmail(String email, String title, String body) {
 
         /* 이메일 메시지 생성 */
@@ -20,6 +57,6 @@ public class MailUtil {
         message.setText(body); /* 이메일 본문 */
 
         /* 이메일 전송 */
-        mailSender.send(message);
+        gmailMailSender.send(message);
     }
 }

--- a/src/main/java/com/beauty4u/backend/config/mail/AsyncConfig.java
+++ b/src/main/java/com/beauty4u/backend/config/mail/AsyncConfig.java
@@ -1,0 +1,22 @@
+package com.beauty4u.backend.config.mail;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+    @Bean
+    public Executor asyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);   // 기본 5개 동시 처리 스레드
+        executor.setMaxPoolSize(10);   // 최대 10개 스레드
+        executor.setQueueCapacity(25); // 대기열 25개
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/beauty4u/backend/config/mail/MailConfig.java
+++ b/src/main/java/com/beauty4u/backend/config/mail/MailConfig.java
@@ -1,0 +1,62 @@
+package com.beauty4u.backend.config.mail;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class MailConfig {
+
+    @Value("${spring.mail.username}")
+    private String mailUserName;
+
+    @Value("${spring.mail.password}")
+    private String mailPassword;
+
+    /* fakeSMTP 사용 mailSender */
+    @Bean
+    @Qualifier("fakeMailSender")
+    public JavaMailSender fakeMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost("localHost");
+        mailSender.setPort(25);
+        mailSender.setProtocol("smtp");
+
+        // 추가 속성 설정
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.transport.protocol", "smtp");
+        props.put("mail.smtp.auth", "false");     // 인증 불필요
+        props.put("mail.smtp.starttls.enable", "false");
+        props.put("mail.debug", "true");     // 디버그 로그 활성화
+
+        return mailSender;
+    }
+
+    /* Gmail SMTP 사용 mailSender */
+    @Bean
+    @Qualifier("gmailMailSender")
+    public JavaMailSender gmailMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost("smtp.gmail.com");
+        mailSender.setPort(587);
+
+        // Gmail 계정 설정
+        mailSender.setUsername(mailUserName);
+        mailSender.setPassword(mailPassword);
+
+        // 추가 속성 설정
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.transport.protocol", "smtp");
+        props.put("mail.smtp.auth", "true");     // 인증 불필요
+        props.put("mail.smtp.starttls.enable", "true");
+        props.put("mail.debug", "true");     // 디버그 로그 활성화
+
+        return mailSender;
+    }
+
+}

--- a/src/main/java/com/beauty4u/backend/promotion/command/application/controller/PromotionNotiController.java
+++ b/src/main/java/com/beauty4u/backend/promotion/command/application/controller/PromotionNotiController.java
@@ -3,7 +3,7 @@ package com.beauty4u.backend.promotion.command.application.controller;
 import com.beauty4u.backend.common.response.ApiResponse;
 import com.beauty4u.backend.common.response.ResponseUtil;
 import com.beauty4u.backend.common.success.SuccessCode;
-import com.beauty4u.backend.promotion.command.application.dto.SavePromotionNotiDTO;
+import com.beauty4u.backend.promotion.command.application.dto.PromotionEmailResult;
 import com.beauty4u.backend.promotion.command.application.dto.UpdatePromotionNotiDTO;
 import com.beauty4u.backend.promotion.command.application.service.PromotionNotiService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,13 +20,22 @@ public class PromotionNotiController {
 
     private final PromotionNotiService promotionNotiService;
 
-    @Operation(summary = "프로모션 알림 등록", description = "프로모션 알림을 등록을 한다.")
+    @Operation(summary = "프로모션 알림 메일 전송", description = "프로모션 알림을 메일로 전송한다. FakeSMTP 사용")
+    @PostMapping("/notiFake/{promotionId}")
+    public ResponseEntity<ApiResponse<PromotionEmailResult>> savePromotionNoti(@PathVariable Long promotionId) {
+
+        PromotionEmailResult result = promotionNotiService.savePromotionNotiFakeSMTP(promotionId);
+
+        return ResponseUtil.successResponse(SuccessCode.PROMOTION_NOTI_SAVE_SUCCESS, result);
+    }
+
+    @Operation(summary = "프로모션 알림 메일 실제 SMTP 서버 전송", description = "프로모션 알림을 실제 메일 서버로 전송한다.")
     @PostMapping("/noti/{promotionId}")
-    public ResponseEntity<ApiResponse<Void>> savePromotionNoti(@PathVariable Long promotionId) {
+    public ResponseEntity<ApiResponse<PromotionEmailResult>> savePromotionNotiReal(@PathVariable Long promotionId) {
 
-        promotionNotiService.savePromotionNoti(promotionId);
+        PromotionEmailResult result = promotionNotiService.sendPromotionNotiGmail(promotionId);
 
-        return ResponseUtil.successResponse(SuccessCode.PROMOTION_NOTI_SAVE_SUCCESS);
+        return ResponseUtil.successResponse(SuccessCode.PROMOTION_NOTI_SAVE_SUCCESS, result);
     }
 
     @Operation(summary = "프로모션 알림 수정", description = "프로모션 알림을 수정 한다.")

--- a/src/main/java/com/beauty4u/backend/promotion/command/application/dto/PromotionEmailResult.java
+++ b/src/main/java/com/beauty4u/backend/promotion/command/application/dto/PromotionEmailResult.java
@@ -1,0 +1,17 @@
+package com.beauty4u.backend.promotion.command.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+public class PromotionEmailResult {
+    private int totalCount;           // 전체 발송 시도 건수
+    private int successCount;         // 성공 건수
+    private int failCount;            // 실패 건수
+    private List<String> failEmails;  // 실패한 이메일 목록
+}

--- a/src/main/java/com/beauty4u/backend/promotion/command/application/service/PromotionNotiService.java
+++ b/src/main/java/com/beauty4u/backend/promotion/command/application/service/PromotionNotiService.java
@@ -1,5 +1,6 @@
 package com.beauty4u.backend.promotion.command.application.service;
 
+import com.beauty4u.backend.promotion.command.application.dto.PromotionEmailResult;
 import com.beauty4u.backend.promotion.command.application.dto.SavePromotionNotiDTO;
 import com.beauty4u.backend.promotion.command.application.dto.UpdatePromotionNotiDTO;
 import com.beauty4u.backend.promotion.command.domain.service.PromotionNotiDomainService;
@@ -14,8 +15,13 @@ public class PromotionNotiService {
     private final PromotionNotiDomainService promotionNotiDomainService;
 
     @Transactional
-    public void savePromotionNoti(Long promotionId) {
-        promotionNotiDomainService.savePromotionNoti(promotionId);
+    public PromotionEmailResult savePromotionNotiFakeSMTP(Long promotionId) {
+        return promotionNotiDomainService.savePromotionNotiFakeSMTP(promotionId);
+    }
+
+    @Transactional
+    public PromotionEmailResult sendPromotionNotiGmail(Long promotionId) {
+        return promotionNotiDomainService.sendPromotionNotiMail(promotionId);
     }
 
     @Transactional

--- a/src/main/java/com/beauty4u/backend/promotion/command/domain/service/PromotionNotiDomainService.java
+++ b/src/main/java/com/beauty4u/backend/promotion/command/domain/service/PromotionNotiDomainService.java
@@ -2,23 +2,190 @@ package com.beauty4u.backend.promotion.command.domain.service;
 
 import com.beauty4u.backend.common.exception.CustomException;
 import com.beauty4u.backend.common.exception.ErrorCode;
+import com.beauty4u.backend.common.util.MailUtil;
+import com.beauty4u.backend.promotion.command.application.dto.PromotionEmailResult;
 import com.beauty4u.backend.promotion.command.application.dto.SavePromotionNotiDTO;
 import com.beauty4u.backend.promotion.command.application.dto.UpdatePromotionNotiDTO;
 import com.beauty4u.backend.promotion.command.domain.aggregate.PromotionNoti;
 import com.beauty4u.backend.promotion.command.domain.repository.PromotionNotiRepository;
+import com.beauty4u.backend.promotion.query.dto.FindPromotionNotiTargetResDTO;
+import com.beauty4u.backend.promotion.query.service.PromotionNotiQueryService;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
 public class PromotionNotiDomainService {
 
     private final PromotionNotiRepository promotionNotiRepository;
+    private final PromotionNotiQueryService promotionNotiQueryService;
     private final ModelMapper modelMapper;
+    private final MailUtil mailUtil;
 
-    public void savePromotionNoti(Long promotionId) {
-        promotionNotiRepository.insertPromotionNotifications(promotionId);
+    /* FakeSMTP 서버 사용 */
+    public PromotionEmailResult savePromotionNotiFakeSMTP(Long promotionId) {
+        List<FindPromotionNotiTargetResDTO> targets = promotionNotiQueryService.findPromotionNotiTarget(promotionId);
+
+        LocalDateTime sendDateTime = LocalDateTime.now();
+        List<CompletableFuture<Void>> emailFutures = new ArrayList<>();
+        Map<String, String> emailMap = new HashMap<>();  // 실패 추적용
+
+        for(FindPromotionNotiTargetResDTO target : targets) {
+            String content = target.getCustomerName()
+                            + " 고객님~! \n"
+                            + "[" + target.getPromotionTitle() + "]\n"
+                            + " 행사 맞이하여 추천상품 \n"
+                            + "[" + target.getGoodsName() + "] \n"
+                            + target.getDiscountRate() + "% 할인된 가격! \n"
+                            + " 특가로 확인해보세요~! \n"
+                            + "언제나 이용해주셔서 감사합니다! \n"
+                            + "beauty4u 드림.";
+
+            CompletableFuture<Void> emailFuture = mailUtil
+                    .sendPromotionFakeSmtpAsync(target.getCustomerEmail(), "beauty4u - [" + target.getPromotionTitle() + "] 프로모션 안내", content)
+                    .exceptionally(throwable -> {
+                        emailMap.put(target.getCustomerEmail(), throwable.getMessage());
+                        return null;
+                    });
+
+            emailFutures.add(emailFuture);
+
+            SavePromotionNotiDTO save = new SavePromotionNotiDTO();
+            save.setCustomerCode(target.getCustomerCode());
+            save.setPromotionNotiContent(content);
+            save.setPromotionNotiSentDate(sendDateTime);
+
+            PromotionNoti saveNoti = modelMapper.map(save, PromotionNoti.class);
+
+            // DB 저장
+            promotionNotiRepository.save(saveNoti);
+        }
+
+        try {
+            CompletableFuture.allOf(emailFutures.toArray(new CompletableFuture[0]))
+                    .get(60, TimeUnit.SECONDS);
+        } catch (Exception e) {
+           System.out.println("Some promotion emails failed to send" + e);
+        }
+
+        return PromotionEmailResult.builder()
+                .totalCount(targets.size())
+                .failCount(emailMap.size())
+                .successCount(targets.size() - emailMap.size())
+                .failEmails(new ArrayList<>(emailMap.keySet()))
+                .build();
+    }
+
+    /* 실제 Google SMTP 서버 사용 */
+    public PromotionEmailResult sendPromotionNotiMail(Long promotionId) {
+
+        LocalDateTime sendDateTime = LocalDateTime.now();
+        List<CompletableFuture<Void>> emailFutures = new ArrayList<>();
+        Map<String, String> emailMap = new HashMap<>();  // 실패 추적용
+
+        String content01 = """
+                황희순 고객님~!\s
+                [2024 크리스마스 기념 윈터 빅세일]\s
+                 행사 맞이하여 추천상품\s
+                [수분 가득 토너]\s
+                25% 할인된 가격!\s
+                 특가로 확인해보세요~!\s
+                언제나 이용해주셔서 감사합니다!\s
+                beauty4u 드림. \s
+                본 메일은 프로모션 이메일 테스트 용입니다.""";
+
+        CompletableFuture<Void> emailFuture1 = mailUtil.sendPromotionGmailAsync("gmltns885@gmail.com", "beauty4u - [2024 크리스마스 기념 윈터 빅세일] 프로모션 안내", content01)
+                         .exceptionally(throwable -> {
+                            emailMap.put("gmltns885@gmail.com", throwable.getMessage());
+                            return null;
+                         });
+
+        emailFutures.add(emailFuture1);
+
+        SavePromotionNotiDTO save1 = new SavePromotionNotiDTO();
+        save1.setCustomerCode("C0011");
+        save1.setPromotionNotiContent(content01);
+        save1.setPromotionNotiSentDate(sendDateTime);
+
+        PromotionNoti saveNoti1 = modelMapper.map(save1, PromotionNoti.class);
+
+        // DB 저장
+        promotionNotiRepository.save(saveNoti1);
+
+        String content02 = """
+                신민철 고객님~!\s
+                [2024 크리스마스 기념 윈터 빅세일]\s
+                 행사 맞이하여 추천상품\s
+                [수분 가득 토너]\s
+                25% 할인된 가격!\s
+                 특가로 확인해보세요~!\s
+                언제나 이용해주셔서 감사합니다!\s
+                beauty4u 드림. \s
+                본 메일은 프로모션 이메일 테스트 용입니다.""";
+
+        CompletableFuture<Void> emailFuture2 = mailUtil.sendPromotionGmailAsync("dbeoalscjf98@naver.com", "beauty4u - [2024 크리스마스 기념 윈터 빅세일] 프로모션 안내", content02)
+                         .exceptionally(throwable -> {
+                            emailMap.put("dbeoalscjf98@naver.com", throwable.getMessage());
+                            return null;
+                        });
+
+        emailFutures.add(emailFuture2);
+
+        SavePromotionNotiDTO save2 = new SavePromotionNotiDTO();
+        save2.setCustomerCode("C0012");
+        save2.setPromotionNotiContent(content02);
+        save2.setPromotionNotiSentDate(sendDateTime);
+
+        PromotionNoti saveNoti2 = modelMapper.map(save2, PromotionNoti.class);
+
+        // DB 저장
+        promotionNotiRepository.save(saveNoti2);
+
+        String content03 = """
+                안세령 고객님~!\s
+                [2024 크리스마스 기념 윈터 빅세일]\s
+                 행사 맞이하여 추천상품\s
+                [수분 가득 토너]\s
+                25% 할인된 가격!\s
+                 특가로 확인해보세요~!\s
+                언제나 이용해주셔서 감사합니다!\s
+                beauty4u 드림. \s
+                본 메일은 프로모션 이메일 테스트 용입니다.""";
+
+        CompletableFuture<Void> emailFuture3 = mailUtil.sendPromotionGmailAsync("sr1094@naver.com", "beauty4u - [2024 크리스마스 기념 윈터 빅세일] 프로모션 안내", content03)
+                         .exceptionally(throwable -> {
+                            emailMap.put("sr1094@naver.com", throwable.getMessage());
+                            return null;
+                        });
+
+        emailFutures.add(emailFuture3);
+
+        SavePromotionNotiDTO save3 = new SavePromotionNotiDTO();
+        save3.setCustomerCode("C0013");
+        save3.setPromotionNotiContent(content02);
+        save3.setPromotionNotiSentDate(sendDateTime);
+
+        PromotionNoti saveNoti3 = modelMapper.map(save3, PromotionNoti.class);
+
+        // DB 저장
+        promotionNotiRepository.save(saveNoti3);
+
+
+        return PromotionEmailResult.builder()
+                .totalCount(3)
+                .failCount(emailMap.size())
+                .successCount(3 - emailMap.size())
+                .failEmails(new ArrayList<>(emailMap.keySet()))
+                .build();
     }
 
     public void updatePromotionNoti(Long id, UpdatePromotionNotiDTO updatePromotionNotiDTO) {

--- a/src/main/java/com/beauty4u/backend/promotion/query/dto/FindPromotionNotiTargetResDTO.java
+++ b/src/main/java/com/beauty4u/backend/promotion/query/dto/FindPromotionNotiTargetResDTO.java
@@ -1,0 +1,17 @@
+package com.beauty4u.backend.promotion.query.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FindPromotionNotiTargetResDTO {
+    private String customerCode;
+    private String customerName;
+    private String customerEmail;
+    private String promotionTitle;
+    private Integer discountRate;
+    private String goodsName;
+}

--- a/src/main/java/com/beauty4u/backend/promotion/query/mapper/PromotionNotiQueryMapper.java
+++ b/src/main/java/com/beauty4u/backend/promotion/query/mapper/PromotionNotiQueryMapper.java
@@ -1,6 +1,7 @@
 package com.beauty4u.backend.promotion.query.mapper;
 
 import com.beauty4u.backend.promotion.query.dto.FindPromotionByCustomerGoodsResDTO;
+import com.beauty4u.backend.promotion.query.dto.FindPromotionNotiTargetResDTO;
 import com.beauty4u.backend.promotion.query.dto.FindPromotionResDTO;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -10,5 +11,6 @@ import java.util.List;
 public interface PromotionNotiQueryMapper {
     Integer findPromotionByCustomerGoodsCount(Integer promotionId);
     List<FindPromotionResDTO> findPromotion(String promotionName);
+    List<FindPromotionNotiTargetResDTO> findPromotionNotiTarget(Long promotionId);
     List<FindPromotionByCustomerGoodsResDTO> findPromotionByCustomerGoods(Integer promotionId, Integer page, Integer count);
 }

--- a/src/main/java/com/beauty4u/backend/promotion/query/service/PromotionNotiQueryService.java
+++ b/src/main/java/com/beauty4u/backend/promotion/query/service/PromotionNotiQueryService.java
@@ -1,6 +1,7 @@
 package com.beauty4u.backend.promotion.query.service;
 
 import com.beauty4u.backend.promotion.query.dto.FindPromotionByCustomerGoodsResDTO;
+import com.beauty4u.backend.promotion.query.dto.FindPromotionNotiTargetResDTO;
 import com.beauty4u.backend.promotion.query.dto.FindPromotionResDTO;
 import com.beauty4u.backend.promotion.query.mapper.PromotionNotiQueryMapper;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,11 @@ public class PromotionNotiQueryService {
     @Transactional
     public List<FindPromotionResDTO> findPromotion(String promotionName) {
         return promotionNotiQueryMapper.findPromotion(promotionName);
+    }
+
+    @Transactional
+    public List<FindPromotionNotiTargetResDTO> findPromotionNotiTarget(Long promotionId) {
+        return promotionNotiQueryMapper.findPromotionNotiTarget(promotionId);
     }
 
     @Transactional

--- a/src/main/resources/mapper/promotion/PromotionNotiQueryMapper.xml
+++ b/src/main/resources/mapper/promotion/PromotionNotiQueryMapper.xml
@@ -31,6 +31,22 @@
         LIMIT #{page}, #{count}
     </select>
 
+    <select id="findPromotionNotiTarget" resultType="FindPromotionNotiTargetResDTO">
+        SELECT
+               c.customer_code,
+               c.customer_name,
+               c.customer_email,
+               p.promotion_title,
+               pg.discount_rate,
+               g.goods_name
+          FROM customer c
+          JOIN personalized_recommendation pr ON c.customer_code = pr.customer_code
+          JOIN goods g ON g.goods_code = pr.goods_code
+          JOIN promotion_goods pg ON pg.goods_code = pr.goods_code
+          JOIN promotion p ON p.promotion_id = pg.promotion_id
+         WHERE pg.promotion_id = #{promotionId}
+    </select>
+
     <select id="findPromotionByCustomerGoodsCount" resultType="java.lang.Integer">
         SELECT
                COUNT(*)


### PR DESCRIPTION
🌟개요
---

🌐연결된 Issues
---
Closes #287

📋작업사항
---
- 프로모션 알림 메일 발송 기능 구현.

✏️작성한 이슈 외 작업사항
---
- 프로모션 테스트용 
경로 : notiFake/[프로모션아이디] 
-> FakeSMTP 서버로 테스트 보내짐. (나중에 실전으로 아마존 서비스로 전환되면 MailUtil 수정)

- 프로모션 실전용 
경로 : noti/[프로모션아이디]
실제 대상자 목록을 불러오고 보내는 것이 아닌 3명 하드코딩으로 처리해놓음.

✅체크리스트
---
- [ ] PR 규칙을 준수하였는가?
- [ ] 이슈번호를 작성하였는가?
- [ ] 추가/수정 사항을 설명하였는가?
