### PR TITLE
feat: 같은 월에 대해서 해당연도와 지난연도의 연령별 매출을 조회하는 기능 추가

### DIFF
--- a/src/main/java/com/beauty4u/backend/common/success/SuccessCode.java
+++ b/src/main/java/com/beauty4u/backend/common/success/SuccessCode.java
@@ -156,6 +156,7 @@ public enum SuccessCode {
     // 제품에 대한 매출
     GOODS_SALES_FIND_SUCCESS(HttpStatus.OK, "제품의 전년 대비 같은 월 비교 성공"),
     GOODS_SALES_MONTHLY_LIST_FIND_SUCCESS(HttpStatus.OK, "제품의 해당 연도 모든 매출액 조회 성공"),
+    GOODS_SALES_AGE_LIST_FIND_SUCCESS(HttpStatus.OK, "제품의 해당 연도와 지난 연도의 같은 달의 연령별 매출액 비교 조회 성공"),
 
     // 폴더 (folder)
     FOLDER_SAVE_SUCCESS(HttpStatus.OK, "폴더 생성 성공"),

--- a/src/main/java/com/beauty4u/backend/goods/query/controller/GoodsSalesQueryController.java
+++ b/src/main/java/com/beauty4u/backend/goods/query/controller/GoodsSalesQueryController.java
@@ -3,10 +3,7 @@ package com.beauty4u.backend.goods.query.controller;
 import com.beauty4u.backend.common.response.ApiResponse;
 import com.beauty4u.backend.common.response.ResponseUtil;
 import com.beauty4u.backend.common.success.SuccessCode;
-import com.beauty4u.backend.goods.query.dto.GoodsSalesFilterDTO;
-import com.beauty4u.backend.goods.query.dto.GoodsSalesMonthlyListFilterDTO;
-import com.beauty4u.backend.goods.query.dto.GoodsSalesMonthlyListResDTO;
-import com.beauty4u.backend.goods.query.dto.GoodsSalesResDTO;
+import com.beauty4u.backend.goods.query.dto.*;
 import com.beauty4u.backend.goods.query.service.GoodsSalesQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -52,5 +49,18 @@ public class GoodsSalesQueryController {
                 = goodsSalesQueryService.findSalesGoodsMonthlyList(goodsCode, goodsSalesMonthlyListFilterDTO);
 
         return ResponseUtil.successResponse(SuccessCode.GOODS_SALES_MONTHLY_LIST_FIND_SUCCESS, goodsSalesMonthlyListResDTO);
+    }
+
+    @Operation(summary = "제품의 해당 연월에 대한 연령별 매출액 조회", description = "제품의 해당 연월에 대한 연령별 매출액을 전연도와 비교해서 조회한다.")
+    @GetMapping("/sales/age/{goodsCode}")
+    public ResponseEntity<ApiResponse<List<GoodsSalesAgeListResDTO>>> findSalesGoodsAge(
+            @PathVariable String goodsCode,
+            GoodsSalesAgeListFilterDTO goodsSalesAgeListFilterDTO
+    ) {
+
+        List<GoodsSalesAgeListResDTO> goodsSalesAgeListResDTO
+                = goodsSalesQueryService.findSalesGoodsAge(goodsCode, goodsSalesAgeListFilterDTO);
+
+        return ResponseUtil.successResponse(SuccessCode.GOODS_SALES_AGE_LIST_FIND_SUCCESS);
     }
 }

--- a/src/main/java/com/beauty4u/backend/goods/query/controller/GoodsSalesQueryController.java
+++ b/src/main/java/com/beauty4u/backend/goods/query/controller/GoodsSalesQueryController.java
@@ -61,6 +61,6 @@ public class GoodsSalesQueryController {
         List<GoodsSalesAgeListResDTO> goodsSalesAgeListResDTO
                 = goodsSalesQueryService.findSalesGoodsAge(goodsCode, goodsSalesAgeListFilterDTO);
 
-        return ResponseUtil.successResponse(SuccessCode.GOODS_SALES_AGE_LIST_FIND_SUCCESS);
+        return ResponseUtil.successResponse(SuccessCode.GOODS_SALES_AGE_LIST_FIND_SUCCESS, goodsSalesAgeListResDTO);
     }
 }

--- a/src/main/java/com/beauty4u/backend/goods/query/dto/GoodsSalesAgeListFilterDTO.java
+++ b/src/main/java/com/beauty4u/backend/goods/query/dto/GoodsSalesAgeListFilterDTO.java
@@ -1,0 +1,16 @@
+package com.beauty4u.backend.goods.query.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GoodsSalesAgeListFilterDTO {
+
+    private int year;
+    private int month;
+}

--- a/src/main/java/com/beauty4u/backend/goods/query/dto/GoodsSalesAgeListResDTO.java
+++ b/src/main/java/com/beauty4u/backend/goods/query/dto/GoodsSalesAgeListResDTO.java
@@ -1,0 +1,18 @@
+package com.beauty4u.backend.goods.query.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GoodsSalesAgeListResDTO {
+
+    private int year;
+    private List<MonthSalesDTO> monthSalesList;
+}

--- a/src/main/java/com/beauty4u/backend/goods/query/dto/MonthSalesDTO.java
+++ b/src/main/java/com/beauty4u/backend/goods/query/dto/MonthSalesDTO.java
@@ -1,0 +1,16 @@
+package com.beauty4u.backend.goods.query.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MonthSalesDTO {
+
+    private int ageUnit;
+    private long sales;
+}

--- a/src/main/java/com/beauty4u/backend/goods/query/mapper/GoodsSalesQueryMapper.java
+++ b/src/main/java/com/beauty4u/backend/goods/query/mapper/GoodsSalesQueryMapper.java
@@ -11,4 +11,12 @@ public interface GoodsSalesQueryMapper {
             @Param("month") Integer month,
             @Param("year") Integer year
     );
+
+    Long findSalesGoodsAge(
+            @Param("goodsCode") String goodsCode,
+            @Param("targetYear") int beforeYear,
+            @Param("targetMonth") int month,
+            @Param("startAge") int startAge,
+            @Param("endAge") int endAge
+    );
 }

--- a/src/main/java/com/beauty4u/backend/goods/query/service/GoodsSalesQueryService.java
+++ b/src/main/java/com/beauty4u/backend/goods/query/service/GoodsSalesQueryService.java
@@ -116,26 +116,34 @@ public class GoodsSalesQueryService {
         int beforeYear = goodsSalesAgeListFilterDTO.getYear() - 1;
         int afterYear = goodsSalesAgeListFilterDTO.getYear();
 
-        List<GoodsSalesAgeListResDTO> = new ArrayList<>();
+        List<GoodsSalesAgeListResDTO> goodsSalesAgeListResDTOS  = new ArrayList<>();
 
         GoodsSalesAgeListResDTO beforeSales = new GoodsSalesAgeListResDTO();
         GoodsSalesAgeListResDTO afterSales = new GoodsSalesAgeListResDTO();
 
+        beforeSales.setMonthSalesList(new ArrayList<>());
+        afterSales.setMonthSalesList(new ArrayList<>());
+
         for (int age : ages) {
 
-            int startAge = age;
             int endAge = age + 10;
+
+            if (age == 60) endAge = 100;
 
             Long beforeSalesGoodsAge = goodsSalesQueryMapper.findSalesGoodsAge(
                     goodsCode,
                     beforeYear,
                     month,
-                    startAge,
+                    age,
                     endAge
             );
 
+            if (beforeSalesGoodsAge == null) {
+                beforeSalesGoodsAge = 0L;
+            }
+
             MonthSalesDTO beforeMonthSalesDTO = new MonthSalesDTO();
-            beforeMonthSalesDTO.setAgeUnit(startAge);
+            beforeMonthSalesDTO.setAgeUnit(age);
             beforeMonthSalesDTO.setSales(beforeSalesGoodsAge);
 
             beforeSales.getMonthSalesList().add(beforeMonthSalesDTO);
@@ -145,18 +153,25 @@ public class GoodsSalesQueryService {
                     goodsCode,
                     afterYear,
                     month,
-                    startAge,
+                    age,
                     endAge
             );
 
+            if (afterSalesGoodsAge == null) {
+                afterSalesGoodsAge = 0L;
+            }
+
             MonthSalesDTO afterMonthSalesDTO = new MonthSalesDTO();
-            afterMonthSalesDTO.setAgeUnit(startAge);
-            afterMonthSalesDTO.setSales(beforeSalesGoodsAge);
+            afterMonthSalesDTO.setAgeUnit(age);
+            afterMonthSalesDTO.setSales(afterSalesGoodsAge);
 
             afterSales.getMonthSalesList().add(afterMonthSalesDTO);
             afterSales.setYear(afterYear);
         }
 
+        goodsSalesAgeListResDTOS.add(beforeSales);
+        goodsSalesAgeListResDTOS.add(afterSales);
 
+        return goodsSalesAgeListResDTOS;
     }
 }

--- a/src/main/java/com/beauty4u/backend/goods/query/service/GoodsSalesQueryService.java
+++ b/src/main/java/com/beauty4u/backend/goods/query/service/GoodsSalesQueryService.java
@@ -2,13 +2,11 @@ package com.beauty4u.backend.goods.query.service;
 
 import com.beauty4u.backend.common.exception.CustomException;
 import com.beauty4u.backend.common.exception.ErrorCode;
-import com.beauty4u.backend.goods.query.dto.GoodsSalesFilterDTO;
-import com.beauty4u.backend.goods.query.dto.GoodsSalesMonthlyListFilterDTO;
-import com.beauty4u.backend.goods.query.dto.GoodsSalesMonthlyListResDTO;
-import com.beauty4u.backend.goods.query.dto.GoodsSalesResDTO;
+import com.beauty4u.backend.goods.query.dto.*;
 import com.beauty4u.backend.goods.query.mapper.GoodsSalesQueryMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,6 +17,7 @@ public class GoodsSalesQueryService {
 
     private final GoodsSalesQueryMapper goodsSalesQueryMapper;
 
+    @Transactional(readOnly = true)
     public GoodsSalesResDTO findSalesGoods(String goodsCode, GoodsSalesFilterDTO goodsSalesFilterDTO) {
 
         Integer month = goodsSalesFilterDTO.getMonth();
@@ -78,6 +77,7 @@ public class GoodsSalesQueryService {
         return Math.round(increaseRate * 10) / 10.0; // 소수점 첫째 자리까지 반올림
     }
 
+    @Transactional(readOnly = true)
     public List<GoodsSalesMonthlyListResDTO> findSalesGoodsMonthlyList(String goodsCode, GoodsSalesMonthlyListFilterDTO goodsSalesMonthlyListFilterDTO) {
 
         List<GoodsSalesMonthlyListResDTO> goodsSalesMonthlyListResDTOS = new ArrayList<>();
@@ -103,5 +103,60 @@ public class GoodsSalesQueryService {
         }
 
         return goodsSalesMonthlyListResDTOS;
+    }
+
+    @Transactional(readOnly = true)
+    public List<GoodsSalesAgeListResDTO> findSalesGoodsAge(
+            String goodsCode, GoodsSalesAgeListFilterDTO goodsSalesAgeListFilterDTO) {
+
+        int[] ages = {10, 20, 30, 40, 50, 60};
+
+        int month = goodsSalesAgeListFilterDTO.getMonth();
+
+        int beforeYear = goodsSalesAgeListFilterDTO.getYear() - 1;
+        int afterYear = goodsSalesAgeListFilterDTO.getYear();
+
+        List<GoodsSalesAgeListResDTO> = new ArrayList<>();
+
+        GoodsSalesAgeListResDTO beforeSales = new GoodsSalesAgeListResDTO();
+        GoodsSalesAgeListResDTO afterSales = new GoodsSalesAgeListResDTO();
+
+        for (int age : ages) {
+
+            int startAge = age;
+            int endAge = age + 10;
+
+            Long beforeSalesGoodsAge = goodsSalesQueryMapper.findSalesGoodsAge(
+                    goodsCode,
+                    beforeYear,
+                    month,
+                    startAge,
+                    endAge
+            );
+
+            MonthSalesDTO beforeMonthSalesDTO = new MonthSalesDTO();
+            beforeMonthSalesDTO.setAgeUnit(startAge);
+            beforeMonthSalesDTO.setSales(beforeSalesGoodsAge);
+
+            beforeSales.getMonthSalesList().add(beforeMonthSalesDTO);
+            beforeSales.setYear(beforeYear);
+
+            Long afterSalesGoodsAge = goodsSalesQueryMapper.findSalesGoodsAge(
+                    goodsCode,
+                    afterYear,
+                    month,
+                    startAge,
+                    endAge
+            );
+
+            MonthSalesDTO afterMonthSalesDTO = new MonthSalesDTO();
+            afterMonthSalesDTO.setAgeUnit(startAge);
+            afterMonthSalesDTO.setSales(beforeSalesGoodsAge);
+
+            afterSales.getMonthSalesList().add(afterMonthSalesDTO);
+            afterSales.setYear(afterYear);
+        }
+
+
     }
 }

--- a/src/main/resources/mapper/goods/GoodsSalesMapper.xml
+++ b/src/main/resources/mapper/goods/GoodsSalesMapper.xml
@@ -13,4 +13,16 @@
         AND order_status = 'PURCHASED'
     </select>
 
+    <select id="findSalesGoodsAge" resultType="Long">
+        SELECT
+            SUM(order_price)
+        FROM order_info o
+        LEFT JOIN customer c on c.customer_code = o.customer_code
+        WHERE o.goods_code = #{goodsCode}
+        AND YEAR(o.created_date) = #{targetYear}
+        AND MONTH(o.created_date) = #{targetMonth}
+        AND c.customer_age <![CDATA[>=]]> #{startAge}
+        AND c.customer_age <![CDATA[<]]> #{endAge}
+    </select>
+
 </mapper>


### PR DESCRIPTION
🌟개요
---
같은 월에 대해서 해당연도와 지난연도의 연령별 매출을 조회하는 기능 추가

🌐연결된 Issues
---
Closes #293

📋작업사항
---
- 같은 월에 대해서 해당 연도와 바로 지난연도와의 연령별 매출을 비교하는 기능 추가

✏️작성한 이슈 외 작업사항
---

✅체크리스트
---
- [ ] PR 규칙을 준수하였는가?
- [ ] 이슈번호를 작성하였는가?
- [ ] 추가/수정 사항을 설명하였는가?
